### PR TITLE
Ensure `spin-path-match-*` and `spin-matched-route` headers are present

### DIFF
--- a/components/request-shape/README.md
+++ b/components/request-shape/README.md
@@ -1,3 +1,7 @@
 # Request Shape
 
 This test ensures that the incoming request to the Spin application has the correct, expected shape.
+
+## Expectations
+
+See the `request-shape` test for both the shape of the request this app expects as well as how the `spin.toml` should look.

--- a/components/request-shape/src/lib.rs
+++ b/components/request-shape/src/lib.rs
@@ -61,7 +61,7 @@ fn check_url(req: &IncomingRequest) -> anyhow::Result<()> {
         .context("authority is not a valid SocketAddr")?;
 
     let path_with_query = req.path_with_query();
-    let expected = "/base/path/end?key=value";
+    let expected = "/base/path/end/rest?key=value";
     anyhow::ensure!(
         path_with_query.as_deref() == Some(expected),
         "URL was expected to be '{expected}' but was '{path_with_query:?}'"
@@ -80,17 +80,17 @@ fn check_url(req: &IncomingRequest) -> anyhow::Result<()> {
 /// Check that the headers are as expected
 fn check_headers(req: &IncomingRequest) -> anyhow::Result<()> {
     let expected_headers = [
-        ("spin-raw-component-route", "/:path_segment/:path_end"),
+        ("spin-raw-component-route", "/:path_segment/:path_end/..."),
         (
             "spin-full-url",
-            "http://example.com/base/path/end?key=value",
+            "http://example.com/base/path/end/rest?key=value",
         ),
-        ("spin-path-info", ""),
+        ("spin-path-info", "/rest"),
         ("spin-base-path", "/base"),
         ("spin-component-route", "/:path_segment/:path_end"),
         ("spin-path-match-path-segment", "path"),
         ("spin-path-match-path-end", "end"),
-        ("spin-matched-route", "/base/:path_segment/:path_end"),
+        ("spin-matched-route", "/base/:path_segment/:path_end/..."),
     ];
 
     let mut actual_headers: HashMap<String, Vec<Vec<u8>>> = HashMap::new();

--- a/components/request-shape/src/lib.rs
+++ b/components/request-shape/src/lib.rs
@@ -80,13 +80,13 @@ fn check_url(req: &IncomingRequest) -> anyhow::Result<()> {
 /// Check that the headers are as expected
 fn check_headers(req: &IncomingRequest) -> anyhow::Result<()> {
     let expected_headers = [
-        ("spin-raw-component-route", "/:path"),
+        ("spin-raw-component-route", "/:path_segment"),
         ("spin-full-url", "http://example.com/base/path?key=value"),
         ("spin-path-info", ""),
         ("spin-base-path", "/base"),
-        ("spin-component-route", "/:path"),
-        ("spin-path-match-path", "path"),
-        ("spin-matched-route", "/base/:path"),
+        ("spin-component-route", "/:path_segment"),
+        ("spin-path-match-path-segment", "path"),
+        ("spin-matched-route", "/base/:path_segment"),
     ];
 
     let mut actual_headers: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
@@ -129,7 +129,7 @@ fn header_as_string(
     if value.len() != 1 {
         anyhow::bail!(
             "expected exactly one header '{name}' but found {}",
-            headers.len()
+            value.len()
         )
     }
     String::from_utf8(value.remove(0))

--- a/components/request-shape/src/lib.rs
+++ b/components/request-shape/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use std::collections::HashMap;
 
 mod bindings {
     wit_bindgen::generate!({
@@ -76,18 +77,25 @@ fn check_url(req: &IncomingRequest) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Check that the headers are as expected
 fn check_headers(req: &IncomingRequest) -> anyhow::Result<()> {
-    // Check that the headers are as expected
-    let headers = [
-        ("spin-raw-component-route", "/..."),
+    let expected_headers = [
+        ("spin-raw-component-route", "/:path"),
         ("spin-full-url", "http://example.com/base/path?key=value"),
-        ("spin-path-info", "/path"),
+        ("spin-path-info", ""),
         ("spin-base-path", "/base"),
-        ("spin-component-route", ""),
+        ("spin-component-route", "/:path"),
+        ("spin-path-match-path", "path"),
+        ("spin-matched-route", "/base/:path"),
     ];
 
-    for (name, value) in headers.into_iter() {
-        let header = header_as_string(req, name)?;
+    let mut actual_headers: HashMap<String, Vec<Vec<u8>>> = HashMap::new();
+    for (k, v) in req.headers().entries() {
+        actual_headers.entry(k).or_default().push(v);
+    }
+
+    for (name, value) in expected_headers.into_iter() {
+        let header = header_as_string(&mut actual_headers, name)?;
 
         anyhow::ensure!(
             header == value,
@@ -96,24 +104,34 @@ fn check_headers(req: &IncomingRequest) -> anyhow::Result<()> {
     }
 
     // Check that the spin-client-addr header is a valid SocketAddr
-    let _: std::net::SocketAddr = header_as_string(req, "spin-client-addr")?
+    let _: std::net::SocketAddr = header_as_string(&mut actual_headers, "spin-client-addr")?
         .parse()
         .context("spin-client-addr header is not a valid SocketAddr")?;
+
+    // Check that there are no unexpected `spin-*` headers
+    for (name, _) in actual_headers {
+        if name.starts_with("spin-") {
+            anyhow::bail!("unexpected special `spin-*` header '{name}' found in request");
+        }
+    }
 
     Ok(())
 }
 
 /// Fails unless there is exactly one header with the given name, and it is valid UTF-8
-fn header_as_string(req: &IncomingRequest, name: &str) -> anyhow::Result<String> {
+fn header_as_string(
+    headers: &mut HashMap<String, Vec<Vec<u8>>>,
+    name: &str,
+) -> anyhow::Result<String> {
     //TODO: handle the fact that headers are case sensitive
-    let mut headers = req.headers().get(&name.to_owned());
+    let mut value = headers.remove(name).unwrap_or_default();
 
-    if headers.len() != 1 {
+    if value.len() != 1 {
         anyhow::bail!(
             "expected exactly one header '{name}' but found {}",
             headers.len()
         )
     }
-    String::from_utf8(headers.remove(0))
+    String::from_utf8(value.remove(0))
         .with_context(|| format!("header '{name}' is not valid UTF-8"))
 }

--- a/tests/request-shape/spin.toml
+++ b/tests/request-shape/spin.toml
@@ -9,7 +9,7 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 base = "/base"
 
 [[trigger.http]]
-route = "/:path_segment"
+route = "/:path_segment/:path_end"
 component = "request-shape"
 
 [component.request-shape]

--- a/tests/request-shape/spin.toml
+++ b/tests/request-shape/spin.toml
@@ -9,7 +9,7 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 base = "/base"
 
 [[trigger.http]]
-route = "/:path"
+route = "/:path_segment"
 component = "request-shape"
 
 [component.request-shape]

--- a/tests/request-shape/spin.toml
+++ b/tests/request-shape/spin.toml
@@ -9,7 +9,7 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 base = "/base"
 
 [[trigger.http]]
-route = "/..."
+route = "/:path"
 component = "request-shape"
 
 [component.request-shape]

--- a/tests/request-shape/spin.toml
+++ b/tests/request-shape/spin.toml
@@ -9,7 +9,7 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 base = "/base"
 
 [[trigger.http]]
-route = "/:path_segment/:path_end"
+route = "/:path_segment/:path_end/..."
 component = "request-shape"
 
 [component.request-shape]

--- a/tests/request-shape/test.json5
+++ b/tests/request-shape/test.json5
@@ -2,7 +2,7 @@
     "invocations": [
         {
             "request": {
-                "path": "/base/path/end?key=value",
+                "path": "/base/path/end/rest?key=value",
                 "headers": [
                     {
                         "name": "User-Agent",

--- a/tests/request-shape/test.json5
+++ b/tests/request-shape/test.json5
@@ -2,7 +2,7 @@
     "invocations": [
         {
             "request": {
-                "path": "/base/path?key=value",
+                "path": "/base/path/end?key=value",
                 "headers": [
                     {
                         "name": "User-Agent",


### PR DESCRIPTION
Fixes #5 

New checks:
* `spin-path-match-*` is properly set
* `spin-matched-route` is properly set
* No unexpected `spin-*` headers are present
  * I would argue that we should reserve these headers and ensure that runtimes are not adding their own.