### PR TITLE
`key-value-no-perms` test

### DIFF
--- a/components/key-value/src/lib.rs
+++ b/components/key-value/src/lib.rs
@@ -3,7 +3,7 @@ use bindings::{
     exports::wasi::http0_2_0::incoming_handler::Guest,
     fermyon::spin2_0_0::key_value::{Error, Store},
     wasi::http0_2_0::types::{
-        ErrorCode, Headers, IncomingRequest, OutgoingResponse, ResponseOutparam,
+        ErrorCode, Headers, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
     },
 };
 
@@ -21,15 +21,21 @@ struct Component;
 impl Guest for Component {
     fn handle(request: IncomingRequest, response_out: ResponseOutparam) {
         let result = handle(request)
-            .map(|_| OutgoingResponse::new(Headers::new()))
+            .map(|r| match r {
+                Some(e) => response(500, format!("{e}").as_bytes()),
+                None => response(200, b""),
+            })
             .map_err(|e| ErrorCode::InternalError(Some(e.to_string())));
         ResponseOutparam::set(response_out, result)
     }
 }
 
-fn handle(_req: IncomingRequest) -> anyhow::Result<()> {
+fn handle(_req: IncomingRequest) -> anyhow::Result<Option<Error>> {
     anyhow::ensure!(matches!(Store::open("forbidden"), Err(Error::AccessDenied)));
-    let store = Store::open("default").context("could not open 'default' store")?;
+    let store = match Store::open("default") {
+        Ok(s) => s,
+        Err(e) => return Ok(Some(e)),
+    };
 
     // Ensure nothing set in `bar` key
     store.delete("bar").context("could not delete 'bar' key")?;
@@ -65,5 +71,20 @@ fn handle(_req: IncomingRequest) -> anyhow::Result<()> {
     anyhow::ensure!(matches!(store.get("qux"), Ok(None)));
     anyhow::ensure!(matches!(store.get_keys().as_deref(), Ok(&[])));
 
-    Ok(())
+    Ok(None)
+}
+
+fn response(status: u16, body: &[u8]) -> OutgoingResponse {
+    let response = OutgoingResponse::new(Headers::new());
+    response.set_status_code(status).unwrap();
+    if !body.is_empty() {
+        let outgoing_body = response.body().unwrap();
+        {
+            let outgoing_stream = outgoing_body.write().unwrap();
+            outgoing_stream.blocking_write_and_flush(body).unwrap();
+            // The outgoing stream must be dropped before the outgoing body is finished.
+        }
+        OutgoingBody::finish(outgoing_body, None).unwrap();
+    }
+    response
 }

--- a/components/key-value/src/lib.rs
+++ b/components/key-value/src/lib.rs
@@ -78,6 +78,7 @@ fn response(status: u16, body: &[u8]) -> OutgoingResponse {
     let response = OutgoingResponse::new(Headers::new());
     response.set_status_code(status).unwrap();
     if !body.is_empty() {
+        assert!(body.len() <= 4096);
         let outgoing_body = response.body().unwrap();
         {
             let outgoing_stream = outgoing_body.write().unwrap();

--- a/components/request-shape/src/lib.rs
+++ b/components/request-shape/src/lib.rs
@@ -12,10 +12,7 @@ mod bindings {
 
 use bindings::{
     exports::wasi::http0_2_0::incoming_handler::{Guest, IncomingRequest, ResponseOutparam},
-    wasi::{
-        cli0_2_0::stdout::get_stdout,
-        http0_2_0::types::{ErrorCode, Headers, OutgoingResponse},
-    },
+    wasi::http0_2_0::types::{ErrorCode, Headers, OutgoingResponse},
 };
 
 use crate::bindings::wasi::http0_2_0::types::{Method, Scheme};
@@ -27,9 +24,6 @@ impl Guest for Component {
         let result = handle(request)
             .map(|_| OutgoingResponse::new(Headers::new()))
             .map_err(|e| ErrorCode::InternalError(Some(e.to_string())));
-        get_stdout()
-            .blocking_write_and_flush(format!("Test Result: {result:?}\n").as_bytes())
-            .unwrap();
         ResponseOutparam::set(response_out, result)
     }
 }

--- a/tests/key-value-no-permission/spin.toml
+++ b/tests/key-value-no-permission/spin.toml
@@ -1,0 +1,13 @@
+spin_manifest_version = 2
+
+[application]
+name = "request-shape"
+version = "0.1.0"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+
+[[trigger.http]]
+route = "/..."
+component = "test"
+
+[component.test]
+source = "%{source=key-value}"

--- a/tests/key-value-no-permission/test.json5
+++ b/tests/key-value-no-permission/test.json5
@@ -1,0 +1,35 @@
+{
+    "invocations": [
+        {
+            "request": {
+                "path": "/",
+                "headers": [
+                    {
+                        "name": "Host",
+                        "value": "example.com"
+                    }
+                ]
+            },
+            "response": {
+                "status": 500,
+                "headers": [
+                    {
+                        "name": "transfer-encoding",
+                        "value": "chunked",
+                        optional: true
+                    },
+                    {
+                        "name": "content-length",
+                        "value": "19",
+                        optional: true
+                    },
+                    {
+                        "name": "Date",
+                        "optional": true
+                    }
+                ],
+                "body": "Error::AccessDenied"
+            }
+        }
+    ],
+}


### PR DESCRIPTION
Also includes some simplification of how we handle HTTP bodies in some of the tests.