### PR TITLE
Add sqlite tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlite-test-component"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "wit-bindgen",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/components/sqlite/Cargo.toml
+++ b/components/sqlite/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sqlite-test-component"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wit-bindgen = { workspace = true }
+anyhow = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]

--- a/components/sqlite/README.md
+++ b/components/sqlite/README.md
@@ -1,0 +1,9 @@
+# Sqlite
+
+Tests the SQLite interface.
+
+## Expectations
+
+This test component expects the following to be true:
+* It is given permission to open a connection to the "default" database.
+* It does not have permission to access a database named "forbidden".

--- a/components/sqlite/src/lib.rs
+++ b/components/sqlite/src/lib.rs
@@ -1,0 +1,81 @@
+use bindings::{
+    exports::wasi::http0_2_0::incoming_handler::Guest,
+    fermyon::spin2_0_0::sqlite::{Connection, Error, Value},
+    wasi::http0_2_0::types::{
+        Headers, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
+    },
+};
+
+mod bindings {
+    wit_bindgen::generate!({
+            world: "http-trigger",
+            path:  "../../wit",
+    });
+    use super::Component;
+    export!(Component);
+}
+
+struct Component;
+impl Guest for Component {
+    fn handle(request: IncomingRequest, response_out: ResponseOutparam) {
+        let result = match handle(request) {
+            Ok(()) => response(200, b""),
+            Err(e) => response(500, format!("{e}").as_bytes()),
+        };
+
+        ResponseOutparam::set(response_out, Ok(result))
+    }
+}
+
+fn handle(_request: IncomingRequest) -> anyhow::Result<()> {
+    anyhow::ensure!(matches!(
+        Connection::open("forbidden"),
+        Err(Error::AccessDenied)
+    ));
+
+    let conn = Connection::open("default")?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS test_data(key TEXT NOT NULL, value TEXT NOT NULL);",
+        &[],
+    )?;
+
+    conn.execute(
+        "INSERT INTO test_data(key, value) VALUES('my_key', 'my_value');",
+        &[],
+    )?;
+
+    let results = conn.execute(
+        "SELECT * FROM test_data WHERE key = ?",
+        &[Value::Text("my_key".to_owned())],
+    )?;
+
+    anyhow::ensure!(results.rows.len() == 1);
+    anyhow::ensure!(results.columns.len() == 2);
+
+    let key_index = results.columns.iter().position(|c| c == "key").unwrap();
+    let value_index = results.columns.iter().position(|c| c == "value").unwrap();
+
+    let fetched_key = &results.rows[0].values[key_index];
+    let fetched_value = &results.rows[0].values[value_index];
+
+    anyhow::ensure!(matches!(fetched_key, Value::Text(t) if t == "my_key"));
+    anyhow::ensure!(matches!(fetched_value, Value::Text(t) if t == "my_value"));
+
+    Ok(())
+}
+
+fn response(status: u16, body: &[u8]) -> OutgoingResponse {
+    let response = OutgoingResponse::new(Headers::new());
+    response.set_status_code(status).unwrap();
+    if !body.is_empty() {
+        assert!(body.len() <= 4096);
+        let outgoing_body = response.body().unwrap();
+        {
+            let outgoing_stream = outgoing_body.write().unwrap();
+            outgoing_stream.blocking_write_and_flush(body).unwrap();
+            // The outgoing stream must be dropped before the outgoing body is finished.
+        }
+        OutgoingBody::finish(outgoing_body, None).unwrap();
+    }
+    response
+}

--- a/crates/conformance-tests/src/config.rs
+++ b/crates/conformance-tests/src/config.rs
@@ -172,6 +172,8 @@ pub enum Precondition {
     /// and it should update any references that test assets make to port 5000 to
     /// the port of the echo server.
     TcpEcho,
+    /// The test expects a sqlite service to be available.
+    Sqlite,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]

--- a/tests/sqlite-no-permission/spin.toml
+++ b/tests/sqlite-no-permission/spin.toml
@@ -1,0 +1,13 @@
+spin_manifest_version = 2
+
+[application]
+name = "sqlite"
+authors = ["Ryan Levick <ryan.levick@fermyon.com>"]
+version = "0.1.0"
+
+[[trigger.http]]
+route = "/"
+component = "test"
+
+[component.test]
+source = "%{source=sqlite}"

--- a/tests/sqlite-no-permission/test.json5
+++ b/tests/sqlite-no-permission/test.json5
@@ -1,0 +1,33 @@
+{
+    "invocations": [
+        {
+            "request": {
+                "path": "/",
+                "headers": [
+                    {
+                        "name": "Host",
+                        "value": "example.com"
+                    }
+                ]
+            },
+            "response": {
+                "status": 500,
+                "headers": [
+                    {
+                        "name": "transfer-encoding",
+                        "optional": true
+                    },
+                    {
+                        "name": "content-length",
+                        "optional": true
+                    },
+                    {
+                        "name": "Date",
+                        "optional": true
+                    }
+                ],
+                "body": "Error::AccessDenied"
+            }
+        }
+    ]
+}

--- a/tests/sqlite/spin.toml
+++ b/tests/sqlite/spin.toml
@@ -1,0 +1,14 @@
+spin_manifest_version = 2
+
+[application]
+name = "sqlite"
+authors = ["Ryan Levick <ryan.levick@fermyon.com>"]
+version = "0.1.0"
+
+[[trigger.http]]
+route = "/"
+component = "test"
+
+[component.test]
+source = "%{source=sqlite}"
+sqlite_databases = ["default"]

--- a/tests/sqlite/test.json5
+++ b/tests/sqlite/test.json5
@@ -1,0 +1,32 @@
+{
+    "invocations": [
+        {
+            "request": {
+                "path": "/",
+                "headers": [
+                    {
+                        "name": "Host",
+                        "value": "example.com"
+                    }
+                ]
+            },
+            "response": {
+                "headers": [
+                    {
+                        "name": "transfer-encoding",
+                        "optional": true
+                    },
+                    {
+                        "name": "content-length",
+                        "optional": true
+                    },
+                    {
+                        "name": "Date",
+                        "optional": true
+                    }
+                ]
+            }
+        }
+    ],
+    "preconditions": [{"kind": "sqlite"}]
+}


### PR DESCRIPTION
This adds tests for SQLite related functionality. 

~I'm unsure how we want to get this working with runtimes that don't have full sqlite implementations like `spin-test`. Somehow, the runtime needs to know the right thing to return for the query.~

I think I will expand the `Sqlite` precondition to encode this information. 