### PR TITLE
Helper crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "helper"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "wit-bindgen",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +676,7 @@ name = "key-value"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "helper",
  "wit-bindgen",
 ]
 
@@ -837,6 +846,7 @@ name = "outbound-redis-test-component"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "helper",
  "wit-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ name = "request-shape"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "helper",
  "wit-bindgen",
 ]
 
@@ -1218,6 +1219,7 @@ name = "sqlite-test-component"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "helper",
  "wit-bindgen",
 ]
 
@@ -1281,6 +1283,7 @@ name = "tcp-sockets-test-component"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "helper",
  "wit-bindgen",
 ]
 
@@ -1521,6 +1524,7 @@ name = "variables"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "helper",
  "wit-bindgen",
 ]
 
@@ -1555,6 +1559,8 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 name = "wasi-http-rust-0-2-0"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "helper",
  "url",
  "wit-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1.0"
+helper = { path = "crates/helper" }
 wit-bindgen = "0.26"

--- a/components/key-value/Cargo.toml
+++ b/components/key-value/Cargo.toml
@@ -8,5 +8,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = { workspace = true }
-helper = { path = "../../crates/helper" }
+helper = { workspace = true }
 wit-bindgen = { workspace = true }

--- a/components/key-value/src/lib.rs
+++ b/components/key-value/src/lib.rs
@@ -4,15 +4,12 @@ struct Component;
 
 helper::gen_http_trigger_bindings!(Component);
 
-use bindings::{
-    exports::wasi::http0_2_0::incoming_handler::Guest,
+use helper::bindings::{
     fermyon::spin2_0_0::key_value::{Error, Store},
-};
-use helper::bindings::wasi::http0_2_0::types::{
-    IncomingRequest, OutgoingResponse, ResponseOutparam,
+    wasi::http0_2_0::types::{IncomingRequest, OutgoingResponse, ResponseOutparam},
 };
 
-impl Guest for Component {
+impl bindings::Guest for Component {
     fn handle(request: IncomingRequest, response_out: ResponseOutparam) {
         helper::handle_result(handle(request), response_out);
     }

--- a/components/outbound-redis/Cargo.toml
+++ b/components/outbound-redis/Cargo.toml
@@ -8,5 +8,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = { workspace = true }
-helper = { path = "../../crates/helper" }
+helper = { workspace = true }
 wit-bindgen = { workspace = true }

--- a/components/outbound-redis/Cargo.toml
+++ b/components/outbound-redis/Cargo.toml
@@ -8,4 +8,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = { workspace = true }
+helper = { path = "../../crates/helper" }
 wit-bindgen = { workspace = true }

--- a/components/outbound-redis/src/lib.rs
+++ b/components/outbound-redis/src/lib.rs
@@ -1,44 +1,28 @@
 use anyhow::Context as _;
-use bindings::{
-    exports::wasi::http0_2_0::incoming_handler::Guest,
-    fermyon::spin2_0_0::redis,
-    wasi::http0_2_0::types::{
-        Headers, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
-    },
-};
 
 struct Component;
 
-mod bindings {
-    wit_bindgen::generate!({
-            world: "http-trigger",
-            path:  "../../wit",
-    });
-    use super::Component;
-    export!(Component);
-}
+helper::gen_http_trigger_bindings!(Component);
+use bindings::{exports::wasi::http0_2_0::incoming_handler::Guest, fermyon::spin2_0_0::redis};
+use helper::bindings::wasi::http0_2_0::types::{
+    IncomingRequest, OutgoingResponse, ResponseOutparam,
+};
 
 impl Guest for Component {
     fn handle(request: IncomingRequest, response_out: ResponseOutparam) {
-        let result = match handle(request) {
-            Err(e) => response(500, format!("{e}").as_bytes()),
-            Ok(r) => r,
-        };
-        ResponseOutparam::set(response_out, Ok(result))
+        helper::handle_result(handle(request), response_out);
     }
 }
 
 const REDIS_ADDRESS_HEADER: &str = "REDIS_ADDRESS";
 
 fn handle(request: IncomingRequest) -> anyhow::Result<OutgoingResponse> {
-    let Some(address) = request
-        .headers()
-        .get(&REDIS_ADDRESS_HEADER.to_owned())
-        .pop()
-        .and_then(|v| String::from_utf8(v).ok())
-    else {
+    let Some(address) = helper::get_header(request, &REDIS_ADDRESS_HEADER.to_owned()) else {
         // Otherwise, return a 400 Bad Request response.
-        return Ok(response(400, b"Bad Request"));
+        return Ok(helper::response(
+            400,
+            format!("missing header: {REDIS_ADDRESS_HEADER}").as_bytes(),
+        ));
     };
     let connection = redis::Connection::open(&address)?;
 
@@ -87,21 +71,5 @@ fn handle(request: IncomingRequest) -> anyhow::Result<OutgoingResponse> {
         values.as_slice(),
         &[redis::RedisResult::Binary(ref b)] if b == b"Eureka! I've got it!"));
 
-    Ok(response(200, b""))
-}
-
-fn response(status: u16, body: &[u8]) -> OutgoingResponse {
-    let response = OutgoingResponse::new(Headers::new());
-    response.set_status_code(status).unwrap();
-    if !body.is_empty() {
-        assert!(body.len() <= 4096);
-        let outgoing_body = response.body().unwrap();
-        {
-            let outgoing_stream = outgoing_body.write().unwrap();
-            outgoing_stream.blocking_write_and_flush(body).unwrap();
-            // The outgoing stream must be dropped before the outgoing body is finished.
-        }
-        OutgoingBody::finish(outgoing_body, None).unwrap();
-    }
-    response
+    Ok(helper::ok_response())
 }

--- a/components/outbound-redis/src/lib.rs
+++ b/components/outbound-redis/src/lib.rs
@@ -3,12 +3,13 @@ use anyhow::Context as _;
 struct Component;
 
 helper::gen_http_trigger_bindings!(Component);
-use bindings::{exports::wasi::http0_2_0::incoming_handler::Guest, fermyon::spin2_0_0::redis};
-use helper::bindings::wasi::http0_2_0::types::{
-    IncomingRequest, OutgoingResponse, ResponseOutparam,
+
+use helper::bindings::{
+    fermyon::spin2_0_0::redis,
+    wasi::http0_2_0::types::{IncomingRequest, OutgoingResponse, ResponseOutparam},
 };
 
-impl Guest for Component {
+impl bindings::Guest for Component {
     fn handle(request: IncomingRequest, response_out: ResponseOutparam) {
         helper::handle_result(handle(request), response_out);
     }

--- a/components/outbound-wasi-http-v0.2.0/Cargo.toml
+++ b/components/outbound-wasi-http-v0.2.0/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+anyhow = { workspace = true }
+helper = { workspace = true }
 url = "2.4.0"
 wit-bindgen = { workspace = true }

--- a/components/request-shape/Cargo.toml
+++ b/components/request-shape/Cargo.toml
@@ -9,5 +9,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = { workspace = true }
 anyhow = { workspace = true }
+helper = { workspace = true }
+wit-bindgen = { workspace = true }

--- a/components/sqlite/Cargo.toml
+++ b/components/sqlite/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-wit-bindgen = { workspace = true }
 anyhow = { workspace = true }
+helper = { workspace = true }
+wit-bindgen = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/components/tcp-sockets/Cargo.toml
+++ b/components/tcp-sockets/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = { workspace = true }
 anyhow = { workspace = true }
+helper = { workspace = true }
+wit-bindgen = { workspace = true }

--- a/components/variables/Cargo.toml
+++ b/components/variables/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wit-bindgen = { workspace = true }
 anyhow = { workspace = true }
+helper = { workspace = true }
+wit-bindgen = { workspace = true }

--- a/crates/helper/Cargo.toml
+++ b/crates/helper/Cargo.toml
@@ -1,12 +1,8 @@
 [package]
-name = "key-value"
+name = "helper"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies]
 anyhow = { workspace = true }
-helper = { path = "../../crates/helper" }
 wit-bindgen = { workspace = true }

--- a/crates/helper/src/lib.rs
+++ b/crates/helper/src/lib.rs
@@ -1,0 +1,70 @@
+///! Helper functions for the conformance test components
+
+pub mod bindings {
+    wit_bindgen::generate!({
+            world: "wasi-http",
+            path:  "../../wit",
+    });
+}
+
+/// Generate bindings for the http-trigger world.
+#[macro_export]
+macro_rules! gen_http_trigger_bindings {
+    ($ident:ident) => {
+        mod bindings {
+            wit_bindgen::generate!({
+                 world: "http-trigger",
+                 path:  "../../wit",
+                 with: {
+                     "wasi:http/types@0.2.0": helper::bindings::wasi::http0_2_0::types,
+                 }
+            });
+            use super::$ident;
+            export!($ident);
+        }
+
+    };
+}
+
+use bindings::wasi::http0_2_0::types::{
+    Headers, IncomingRequest, OutgoingBody, OutgoingResponse, ResponseOutparam,
+};
+
+/// Create a response with the given status code and body.
+pub fn response(status: u16, body: &[u8]) -> OutgoingResponse {
+    let response = OutgoingResponse::new(Headers::new());
+    response.set_status_code(status).unwrap();
+    if !body.is_empty() {
+        assert!(body.len() <= 4096);
+        let outgoing_body = response.body().unwrap();
+        {
+            let outgoing_stream = outgoing_body.write().unwrap();
+            outgoing_stream.blocking_write_and_flush(body).unwrap();
+            // The outgoing stream must be dropped before the outgoing body is finished.
+        }
+        OutgoingBody::finish(outgoing_body, None).unwrap();
+    }
+    response
+}
+
+/// Handle the result of a function that returns an `OutgoingResponse`.
+pub fn handle_result(result: anyhow::Result<OutgoingResponse>, response_out: ResponseOutparam) {
+    let result = match result {
+        Err(e) => response(500, format!("{e}").as_bytes()),
+        Ok(response) => response,
+    };
+    ResponseOutparam::set(response_out, Ok(result))
+}
+
+pub fn get_header(request: IncomingRequest, header_key: &String) -> Option<String> {
+    request
+        .headers()
+        .get(header_key)
+        .pop()
+        .and_then(|v| String::from_utf8(v).ok())
+}
+
+/// Create a response with a 200 status code and an empty body.
+pub fn ok_response() -> OutgoingResponse {
+    response(200, b"")
+}

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -39,7 +39,3 @@ world platform-rc20231018 {
   import key-value;
   import variables;
 }
-
-world wasi-http {
-  import wasi:http/types@0.2.0;
-}

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -39,3 +39,7 @@ world platform-rc20231018 {
   import key-value;
   import variables;
 }
+
+world wasi-http {
+  import wasi:http/types@0.2.0;
+}


### PR DESCRIPTION
Fixes #8 

This adds a very small and purposefully minimal helper crate. The goal with helper crate is to maintain clarity in the tests while reducing some of the boilerplate (particularly around incoming-http). 