### PR TITLE
Custom services

### DIFF
--- a/crates/test-environment/src/services.rs
+++ b/crates/test-environment/src/services.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -21,23 +21,16 @@ impl Services {
     /// Start all the required services given a path to service definitions
     pub fn start(config: &ServicesConfig, working_dir: &Path) -> anyhow::Result<Self> {
         let mut services = Vec::new();
-        for required_service in &config.services {
-            let service_definition_extension =
-                config.definitions.get(required_service).map(|e| e.as_str());
-            let mut service: Box<dyn Service> = match service_definition_extension {
-                Some("py") => Box::new(PythonService::start(
-                    required_service,
-                    &config.definitions_path,
+        for service_def in &config.service_definitions {
+            let mut service: Box<dyn Service> = match &service_def.kind {
+                ServiceKind::Python { script } => Box::new(PythonService::start(
+                    &service_def.name,
+                    script,
                     working_dir,
                 )?),
-                Some("Dockerfile") => Box::new(DockerService::start(
-                    required_service,
-                    &config.definitions_path,
-                )?),
-                Some(extension) => {
-                    bail!("service definitions with the '{extension}' extension are not supported")
+                ServiceKind::Docker { dockerfile } => {
+                    Box::new(DockerService::start(&service_def.name, dockerfile)?)
                 }
-                None => bail!("no service definition found for '{required_service}'"),
             };
             service.ready()?;
             services.push(service);
@@ -88,37 +81,43 @@ impl<'a> IntoIterator for &'a Services {
 }
 
 pub struct ServicesConfig {
-    services: Vec<String>,
-    definitions_path: PathBuf,
-    definitions: HashMap<String, String>,
+    /// Definitions of all services to be used.
+    service_definitions: Vec<ServiceDefinition>,
 }
 
 impl ServicesConfig {
-    /// Create a new services config a list of services to start.
+    /// Create a new services config with a list of built-in services to start.
     ///
-    /// The services are expected to have a definition file in the `services` directory with the same name as the service.
-    pub fn new(services: Vec<String>) -> anyhow::Result<Self> {
-        let definitions = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("services");
-        let service_definitions = service_definitions(&definitions)?;
+    /// The built-in services are expected to have a definition file in the `services` directory with the same name as the service.
+    pub fn new(builtins: HashSet<&str>) -> anyhow::Result<Self> {
+        let definitions_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("services");
+        let service_definitions = get_builtin_service_definitions(builtins, &definitions_path)?;
         Ok(Self {
-            services,
-            definitions_path: definitions,
-            definitions: service_definitions,
+            service_definitions,
         })
+    }
+
+    pub fn add_service(&mut self, service: ServiceDefinition) {
+        self.service_definitions.push(service);
     }
 
     /// Configure no services
     pub fn none() -> Self {
         Self {
-            services: Vec::new(),
-            definitions_path: PathBuf::new(),
-            definitions: HashMap::new(),
+            service_definitions: Vec::new(),
         }
     }
 }
 
 /// Get all of the service definitions returning a HashMap of the service name to the service definition file extension.
-fn service_definitions(service_definitions_path: &Path) -> anyhow::Result<HashMap<String, String>> {
+fn get_builtin_service_definitions(
+    mut builtins: HashSet<&str>,
+    service_definitions_path: &Path,
+) -> anyhow::Result<Vec<ServiceDefinition>> {
+    if builtins.is_empty() {
+        return Ok(Vec::new());
+    }
+
     std::fs::read_dir(service_definitions_path)
         .with_context(|| {
             format!(
@@ -139,8 +138,39 @@ fn service_definitions(service_definitions_path: &Path) -> anyhow::Result<HashMa
                 .context("service definition did not have an extension")?;
             Ok((file_name.to_owned(), file_extension.to_owned()))
         })
-        .filter(|r| !matches!( r , Ok((_, extension)) if extension == "lock"))
+        .filter(|r| !matches!(r, Ok((_, extension)) if extension == "lock"))
+        .filter(move |r| match r {
+            Ok((service, _)) => builtins.remove(service.as_str()),
+            _ => false,
+        })
+        .map(|r| {
+            let (name, extension) = r?;
+            Ok(ServiceDefinition {
+                name: name.clone(),
+                kind: match extension.as_str() {
+                    "py" => ServiceKind::Python {
+                        script: service_definitions_path.join(format!("{}.py", name)),
+                    },
+                    "Dockerfile" => ServiceKind::Docker {
+                        dockerfile: service_definitions_path.join(format!("{}.Dockerfile", name)),
+                    },
+                    _ => bail!("unsupported service definition extension '{}'", extension),
+                },
+            })
+        })
         .collect()
+}
+
+/// A service definition.
+pub struct ServiceDefinition {
+    name: String,
+    kind: ServiceKind,
+}
+
+/// The kind of service.
+pub enum ServiceKind {
+    Python { script: PathBuf },
+    Docker { dockerfile: PathBuf },
 }
 
 /// An external service a test may depend on.

--- a/crates/test-environment/src/services/python.rs
+++ b/crates/test-environment/src/services/python.rs
@@ -19,11 +19,13 @@ pub struct PythonService {
 }
 
 impl PythonService {
-    pub fn start(name: &str, script_path: &Path, working_dir: &Path) -> anyhow::Result<Self> {
-        let lock_path = script_path
-            .parent()
-            .context("Python script path has no parent")?
-            .join(format!("{name}.lock"));
+    pub fn start(
+        name: &str,
+        script_path: &Path,
+        working_dir: &Path,
+        lock_dir: &Path,
+    ) -> anyhow::Result<Self> {
+        let lock_path = lock_dir.join(format!("{name}.lock"));
         let mut lock =
             fslock::LockFile::open(&lock_path).context("failed to open service file lock")?;
         lock.lock().context("failed to obtain service file lock")?;

--- a/crates/test-environment/src/test_environment.rs
+++ b/crates/test-environment/src/test_environment.rs
@@ -25,7 +25,7 @@ impl<R: Runtime> TestEnvironment<R> {
         config: TestEnvironmentConfig<R>,
         init_env: impl FnOnce(&mut Self) -> anyhow::Result<()> + 'static,
     ) -> anyhow::Result<Self> {
-        let mut env = Self::boot(&config.services_config)?;
+        let mut env = Self::boot(config.services_config)?;
         init_env(&mut env)?;
         let runtime = (config.create_runtime)(&mut env)?;
         env.start_runtime(runtime)
@@ -47,7 +47,7 @@ impl<R> TestEnvironment<R> {
     /// Spin up a test environment without a runtime
     ///
     /// `services` specifies the services to run.
-    pub fn boot(services: &ServicesConfig) -> anyhow::Result<Self> {
+    pub fn boot(services: ServicesConfig) -> anyhow::Result<Self> {
         let temp = temp_dir::TempDir::new()
             .context("failed to produce a temporary directory to run the test in")?;
         let mut services =

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn package_into(dir_path: impl AsRef<Path>) -> anyhow::Result<()> {
             continue;
         }
         let test_path = test.path();
-        println!("Processing test {:?}...", test_path);
+        println!("Processing {test_path:?}...");
 
         let test_name = test_path
             .file_name()
@@ -180,7 +180,6 @@ fn substitute_source(
                     .with_context(|| format!("'{template_value}' is not a known component"))?;
                 let component_file = "component.wasm";
                 std::fs::copy(path, test_archive.join(component_file))?;
-                println!("Substituting {template} with {component_file}...");
                 manifest.replace_range(full.range(), component_file);
                 // Restart the search after a substitution
                 continue 'outer;


### PR DESCRIPTION
This allows for running custom services that are not provided as a built-in service.

Some runtimes might be niche or proprietary, and so it doesn't make sense for their dependent services to be built-in to the test-environment framework, but we still want to allow them to add their own services. 