### PR TITLE
Assert that the authority is equal to the host header

### DIFF
--- a/components/request-shape/src/lib.rs
+++ b/components/request-shape/src/lib.rs
@@ -36,9 +36,8 @@ fn check_url(req: &IncomingRequest) -> anyhow::Result<()> {
     let authority = req
         .authority()
         .context("incoming request has no authority")?;
-    let _addr: std::net::SocketAddr = authority
-        .parse()
-        .context("authority is not a valid SocketAddr")?;
+    // The authority is equal to the original request's HOST header
+    assert_eq!(authority, "example.com");
 
     let path_with_query = req.path_with_query();
     let expected = "/base/path/end/rest?key=value";


### PR DESCRIPTION
We need to wait until Spin has support for this before merging. 