### PR TITLE
Requests can be either HTTP or HTTPS

### DIFF
--- a/components/request-shape/src/lib.rs
+++ b/components/request-shape/src/lib.rs
@@ -48,10 +48,9 @@ fn check_url(req: &IncomingRequest) -> anyhow::Result<()> {
     );
 
     let scheme = req.scheme();
-    let expected = Scheme::Http;
     anyhow::ensure!(
-        matches!(scheme, Some(Scheme::Http)),
-        "Scheme was expected to be '{expected:?}' but was '{scheme:?}'"
+        matches!(scheme, Some(Scheme::Http | Scheme::Https)),
+        "Scheme was expected to be HTTP or HTTPS but was '{scheme:?}'"
     );
 
     Ok(())


### PR DESCRIPTION
Incoming requests can be either HTTP or HTTPs depending on however the implementing runtime chooses to expose that information to the guest. Typically, if the request is originally made over HTTPs then the guest will see Scheme::HTTPS and otherwise, it will see HTTP.