### PR TITLE
Change request shape test to reflect removal of base

### DIFF
--- a/components/request-shape/src/lib.rs
+++ b/components/request-shape/src/lib.rs
@@ -58,14 +58,18 @@ fn check_url(req: &IncomingRequest) -> anyhow::Result<()> {
 /// Check that the headers are as expected
 fn check_headers(req: &IncomingRequest) -> anyhow::Result<()> {
     let expected_headers = [
-        ("spin-raw-component-route", "/:path_segment/:path_end/..."),
+        (
+            "spin-raw-component-route",
+            "/base/:path_segment/:path_end/...",
+        ),
         (
             "spin-full-url",
             "http://example.com/base/path/end/rest?key=value",
         ),
         ("spin-path-info", "/rest"),
-        ("spin-base-path", "/base"),
-        ("spin-component-route", "/:path_segment/:path_end"),
+        // Hardcoded base path for backwards compatibility
+        ("spin-base-path", "/"),
+        ("spin-component-route", "/base/:path_segment/:path_end"),
         ("spin-path-match-path-segment", "path"),
         ("spin-path-match-path-end", "end"),
         ("spin-matched-route", "/base/:path_segment/:path_end/..."),

--- a/tests/request-shape/spin.toml
+++ b/tests/request-shape/spin.toml
@@ -5,11 +5,8 @@ name = "request-shape"
 version = "0.1.0"
 authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 
-[application.trigger.http]
-base = "/base"
-
 [[trigger.http]]
-route = "/:path_segment/:path_end/..."
+route = "/base/:path_segment/:path_end/..."
 component = "request-shape"
 
 [component.request-shape]


### PR DESCRIPTION
The only question I have is if we should keep the `"spin-base-path"` header which is now just hardcoded to "/". This is a breaking change already, so why not just remove this special header?