### PR TITLE
Change where the HttpRequestDenied is returned

### DIFF
--- a/tests/outbound-wasi-http-v0.2.0-no-perms/test.json5
+++ b/tests/outbound-wasi-http-v0.2.0-no-perms/test.json5
@@ -28,7 +28,7 @@
                         "optional": true
                     }
                 ],
-                "body": "ErrorCode::HttpRequestDenied"
+                "body": "incoming-response#get: ErrorCode::HttpRequestDenied"
             },
         }
     ],


### PR DESCRIPTION
`HttpRequestDenied` errors are now returned async instead of immediately upon calling `outgoing-handler/handle`. I sort of think this is a worse behavior, and I do think we should figure out if it would be possible to keep the older behavior. 