### PR TITLE
Support a non-exiting run mode

### DIFF
--- a/crates/conformance-tests/src/lib.rs
+++ b/crates/conformance-tests/src/lib.rs
@@ -33,21 +33,21 @@ impl Config {
     }
 }
 
-/// Run the conformance tests
+/// Run the conformance tests and return the results.
 pub fn run_tests(
     config: Config,
     run: impl Fn(Test) -> anyhow::Result<()> + Send + Clone + 'static,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<libtest_mimic::Conclusion> {
     let tests_dir = download_tests(&config.version)?;
     run_tests_from(tests_dir, config, run)
 }
 
-/// Run the conformance tests located in the given directory
+/// Run the conformance tests located in the given directory and returns the Conclusion
 pub fn run_tests_from(
     tests_dir: impl AsRef<Path>,
     config: Config,
     run: impl Fn(Test) -> anyhow::Result<()> + Send + Clone + 'static,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<libtest_mimic::Conclusion> {
     let trials = tests_iter(tests_dir)?
         .map(|test| {
             let run = run.clone();
@@ -56,7 +56,7 @@ pub fn run_tests_from(
                 .with_ignored_flag(config.ignored.contains(&name))
         })
         .collect();
-    libtest_mimic::run(&Default::default(), trials).exit();
+    Ok(libtest_mimic::run(&Default::default(), trials))
 }
 
 /// Download the conformance tests and return the path to the directory where they are written to


### PR DESCRIPTION
The Spin runtime tests use `conformance-tests` as a library (https://github.com/fermyon/spin/blob/967fdf368612478cef176bccc491faffad680050/tests/runtime.rs#L31).  However, `run_tests` entry point calls `libmimic::Conclusion::exit()`, which causes the test process to exit at the end of the tests, with the result of the `libmimic` tests _only_.  This means that if a Spin runtime test fails but all conformance tests succeed, the overall test suite still passes, disguising the test failure unless the avid reader pores over the logs.

This PR proposes splitting the `run_tests` entry point into `run_tests_and_exit`, which retains the current behaviour, and `run_tests_to_conclusion`, which instead returns the Conclusion object.  `libmimic` still prints all progress and results as normal.

With this in place, the Spin runtime test that checks conformance will be able to examine `Conclusion::has_failed` and propagate failure (e.g. by returning an error such as "One or more conformance tests failed") or pass on success, without interfering with other tests.

Of course the names and behaviour are totally up for grabs (some names are deliberate to make consumers aware of changed behaviour, but that may be misguided), and if you feel there's a better way of managing this then please feel free to circular-file this - I'm not at all familiar with the code base or with other use cases I'm afraid.
